### PR TITLE
add battery amperage in mA

### DIFF
--- a/Apple Juice/ApplicationController.swift
+++ b/Apple Juice/ApplicationController.swift
@@ -83,12 +83,13 @@ final class ApplicationController: NSObject {
         guard
             let capacity   = battery.capacity,
             let charge     = battery.charge,
+            let amperage   = battery.amperage,
             let percentage = battery.percentage else {
                 return
         }
 
         currentSource.title = "\(NSLocalizedString("Power Source", comment: "")) \(battery.powerSource)"
-        currentCharge.title = "\(battery.timeRemainingFormatted) (\(charge) / \(capacity) mAh)"
+        currentCharge.title = "\(battery.timeRemainingFormatted) (\(charge) / \(capacity) mAh / \(amperage) mA)"
 
         if UserPreferences.showTime {
             currentCharge.title = "\(percentage) % (\(charge) / \(capacity) mAh)"

--- a/Apple Juice/BatteryService.swift
+++ b/Apple Juice/BatteryService.swift
@@ -138,6 +138,15 @@ final class BatteryService {
         return round(((voltage * amperage) / 1_000_000) * 10) / 10
     }
 
+    ///  Current flowing into or out of the battery.
+    var amperage: Int? {
+        guard
+            let amperage = getRegistryProperty(forKey: .amperage) as? Int else {
+                return nil
+        }
+        return amperage
+    }
+
     /// The number of charging cycles.
     var cycleCount: Int? {
         return getRegistryProperty(forKey: .cycleCount) as? Int


### PR DESCRIPTION
Having problems with some repaired chargers indicating
they are charging when they aren't.

Being able to easily view charge and discharge rate
in mA is helpful for diagnosing problems.