### PR TITLE
Add note about installing using brew to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,20 @@ Get even more information about your current battery status, without cluttering 
 Probably as accurate as it gets. The information come directly from macOS’s IO registry and are updated constantly.
 
 ## How do I install it? ##
-You have two options:
 
-1. Download the [latest binary](https://github.com/raphaelhanneken/apple-juice/releases/latest) and drop it into your `Applications folder`*.
+You have three options:
 
-2. Download the source code and build it yourself, with Xcode. You'll also need to install [Carthage](https://github.com/Carthage/Carthage), if you haven’t done so already, and run `carthage update` from your Terminal. Otherwise Xcode won't find the [Sparkle Framework](https://github.com/sparkle-project/Sparkle), since I haven’t put it under version control. 
+1. Install using [brew](https://brew.sh/):
+
+`brew cask install apple-juice`
+
+2. Install from published binary:
+
+Download the [latest binary](https://github.com/raphaelhanneken/apple-juice/releases/latest) and drop it into your `Applications folder`*.
+
+3. Build binary locally from source code:
+
+Download the source code and build it yourself, with Xcode. You'll also need to install [Carthage](https://github.com/Carthage/Carthage), if you haven’t done so already, and run `carthage update` from your Terminal. Otherwise Xcode won't find the [Sparkle Framework](https://github.com/sparkle-project/Sparkle), since I haven’t put it under version control. 
 
 *Since I don’t have an Apple Developer account, you have to allow third party apps within the system preferences.
  ```System Preferences: Security & Privacy: Allow apps downloaded from: Anywhere```.


### PR DESCRIPTION
There is a cask formula available for installing Apple Juice using brew (see [apple-juice.rb](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/apple-juice.rb)), this may be the easiest installation method.